### PR TITLE
Initial support for Jenkins slave automation

### DIFF
--- a/elk.yml
+++ b/elk.yml
@@ -1,6 +1,10 @@
 # vim: ft=ansible
 ---
 - hosts: elasticsearch
+  tags:
+    - elasticsearch
+    - elk
+
   vars_files:
     - "{{ inventory_dir  }}/../vars/main.yml"
 
@@ -9,6 +13,10 @@
     - { role: 'leifmadsen.elasticsearch' }
 
 - hosts: logstash
+  tags:
+    - logstash
+    - elk
+
   vars_files:
     - "{{ inventory_dir  }}/../vars/main.yml"
 
@@ -17,6 +25,10 @@
     - { role: 'leifmadsen.logstash' }
 
 - hosts: kibana
+  tags:
+    - kibana
+    - elk
+
   vars_files:
     - "{{ inventory_dir  }}/../vars/main.yml"
 

--- a/jenkins.yml
+++ b/jenkins.yml
@@ -3,6 +3,9 @@
 
 # Deploy Jenkins Master
 - hosts: jenkins_master
+  tags:
+    - jenkins_master
+
   vars_files:
     - "{{ inventory_dir  }}/../vars/main.yml"
     - ~/.ansible/vars/cira_vars.yml
@@ -12,7 +15,7 @@
 
   roles:
     - { role: 'geerlingguy.nginx' }
-    - { role: 'geerlingguy.jenkins' }
+    - { role: 'leifmadsen.jenkins' }
 
   post_tasks:
     - name: Add jenkins user to wheel group
@@ -112,11 +115,16 @@
 
 # Deploy jobs via JJB
 - hosts: jenkins_master
+  tags:
+    - jenkins_master
+
   vars_files:
     - "{{ inventory_dir  }}/../vars/main.yml"
     - ~/.ansible/vars/cira_vars.yml
 
   pre_tasks:
+    - include: requiretty.yml
+
     - name: Validate Git is installed
       yum:
         name: git
@@ -179,6 +187,8 @@
 
 # Deploy Jenkins Slave
 - hosts: jenkins_slave
+  tags:
+    - jenkins_slave
   tasks:
 
     # TODO: this is a work around because I haven't figured out how to properly
@@ -190,6 +200,12 @@
       tags:
         # Skip ANSIBLE0015. Use of bare variable jenkins_master is correct.
         - skip_ansible_lint
+
+    - name: Ensure libselinux-python is installed
+      become: yes
+      yum:
+        name: libselinux-python
+        state: present
 
     - name: Create jenkins user
       become: yes

--- a/jenkins.yml
+++ b/jenkins.yml
@@ -19,6 +19,16 @@
     sudo_defaults:
       - defaults: '!requiretty'
 
+  tasks:
+    - name: Set facts for later use
+      set_fact:
+        jenkins_jar_location: "{{ jenkins_jar_location }}"
+        jenkins_hostname: "{{ jenkins_hostname }}"
+        jenkins_http_port: "{{ jenkins_http_port }}"
+        jenkins_url_prefix: "{{ jenkins_url_prefix }}"
+        jenkins_admin_username: "{{ jenkins_admin_username }}"
+        jenkins_admin_password: "{{ jenkins_admin_password }}"
+
   post_tasks:
     - name: Add jenkins user to wheel group
       user:
@@ -253,3 +263,45 @@
       authorized_key:
         user: root
         key: "{{ jenkins_slave_pub.stdout }}"
+
+- hosts: jenkins_master
+  become: yes
+  tags:
+    - jenkins_slave_test
+
+  vars_files:
+    - ~/.ansible/vars/cira_vars.yml
+
+  tasks:
+    # TODO: This is kind of hacky since it doesn't deal with multiple jenkins
+    #       slaves. We'll need to circle back and make this deal with lists.
+    - name: Check if our node already exists
+      ignore_errors: true
+      command: >
+        java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix | default('') }}/
+        get-node {{ slave_name }}
+        --username {{ jenkins_admin_username }}
+        --password {{ jenkins_admin_password }}
+      register: jenkins_cli_get_node
+
+    - debug: var=jenkins_cli_get_node
+
+    - name: Deploy template for Jenkins slave node
+      template:
+        src: jenkins_slave.j2
+        dest: /tmp/jenkins_slave_{{ slave_name }}.tmpl
+      when: jenkins_cli_get_node.stderr is defined and jenkins_cli_get_node.stderr != ""
+
+    - name: Add Jenkins slave node to the master
+      shell: >
+        java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix | default('') }}/
+        create-node {{ slave_name }}
+        --username {{ jenkins_admin_username }}
+        --password {{ jenkins_admin_password }} < /tmp/jenkins_slave_{{ slave_name }}.tmpl
+      when: jenkins_cli_get_node.stderr is defined and jenkins_cli_get_node.stderr != ""
+
+    - name: Remove template for Jenkins slave node
+      file:
+        name: /tmp/jenkins_slave_{{ slave_name }}.tmpl
+        state: absent
+      when: slave_name is defined and jenkins_cli_get_node.stderr != ""

--- a/jenkins.yml
+++ b/jenkins.yml
@@ -10,12 +10,14 @@
     - "{{ inventory_dir  }}/../vars/main.yml"
     - ~/.ansible/vars/cira_vars.yml
 
-  pre_tasks:
-    - include: requiretty.yml
-
   roles:
+    - { role: 'franklinkim.sudo' }
     - { role: 'geerlingguy.nginx' }
     - { role: 'leifmadsen.jenkins' }
+
+  vars:
+    sudo_defaults:
+      - defaults: '!requiretty'
 
   post_tasks:
     - name: Add jenkins user to wheel group
@@ -123,8 +125,6 @@
     - ~/.ansible/vars/cira_vars.yml
 
   pre_tasks:
-    - include: requiretty.yml
-
     - name: Validate Git is installed
       yum:
         name: git
@@ -187,13 +187,32 @@
 
 # Deploy Jenkins Slave
 - hosts: jenkins_slave
+  become: yes
+  roles:
+    - { role: 'franklinkim.sudo' }
+
+  vars:
+    sudo_defaults:
+      - name: 'jenkins'
+        defaults: '!requiretty'
+    sudo_users:
+      - name: 'jenkins'
+        nopasswd: yes
+
   tags:
     - jenkins_slave
+
   tasks:
+    - name: Validate Git is installed
+      yum:
+        name: git
+        state: present
 
     # TODO: this is a work around because I haven't figured out how to properly
     #       access the registered hostvars on the jenkins_master.
     - name: Set fact containing the jenkins_master SSH public key
+      become: no
+      ignore_errors: yes
       set_fact:
         jenkins_master_pub: "{{ hostvars[item].jenkins_master_pub.stdout }}"
       with_inventory_hostnames: jenkins_master
@@ -202,20 +221,17 @@
         - skip_ansible_lint
 
     - name: Ensure libselinux-python is installed
-      become: yes
       yum:
         name: libselinux-python
         state: present
 
     - name: Create jenkins user
-      become: yes
       user:
         name: jenkins
         comment: "Jenkins Slave User"
         generate_ssh_key: yes
 
     - name: Get contents of jenkins public key
-      become: yes
       command: cat /home/jenkins/.ssh/id_rsa.pub
       register: jenkins_slave_pub
       tags:
@@ -223,11 +239,17 @@
         - skip_ansible_lint
 
     - name: Add authorized host keys to authorized_keys
-      become: yes
       become_user: jenkins
+      ignore_errors: yes
       authorized_key:
         user: jenkins
         key: "{{ item }}"
       with_items:
       - "{{ jenkins_master_pub }}"
       - "{{ jenkins_slave_pub.stdout }}"
+
+    - name: Add jenkins public key to local root user
+      become: yes
+      authorized_key:
+        user: root
+        key: "{{ jenkins_slave_pub.stdout }}"

--- a/openstack.yml
+++ b/openstack.yml
@@ -2,7 +2,7 @@
 - name: Deploy on OpenStack
   hosts: localhost
   tags:
-    - openstack
+    - always
 
   gather_facts: false
   vars_files:

--- a/openstack.yml
+++ b/openstack.yml
@@ -1,6 +1,9 @@
 # vim: set ft=ansible
 - name: Deploy on OpenStack
   hosts: localhost
+  tags:
+    - openstack
+
   gather_facts: false
   vars_files:
     - ~/.ansible/vars/cira_vars.yml

--- a/requirements.yml
+++ b/requirements.yml
@@ -14,3 +14,4 @@
 - src: https://github.com/leifmadsen/ansible-role-jenkins-job-builder.git
   version: master
   name: leifmadsen.jenkins-job-builder
+- src: franklinkim.sudo

--- a/requirements.yml
+++ b/requirements.yml
@@ -8,7 +8,9 @@
   name: leifmadsen.logstash
 - src: geerlingguy.nginx
 - src: leifmadsen.kibana-4
-- src: geerlingguy.jenkins
+- src: https://github.com/leifmadsen/ansible-role-jenkins.git
+  version: master
+  name: leifmadsen.jenkins
 - src: https://github.com/leifmadsen/ansible-role-jenkins-job-builder.git
   version: master
   name: leifmadsen.jenkins-job-builder

--- a/requiretty.yml
+++ b/requiretty.yml
@@ -1,8 +1,0 @@
----
-- name: Detect /etc/sudoers
-  stat: path=/etc/sudoers
-  register: etc_sudoers
-
-- name: Disable sudo requiretty for Ansible pipelining
-  lineinfile: dest=/etc/sudoers regexp="^Defaults(\s+)(.*)requiretty(.*)" line="#Defaults\1\2requiretty\3" backrefs=yes
-  when: etc_sudoers.stat.exists

--- a/site.yml
+++ b/site.yml
@@ -14,12 +14,19 @@
 
 # Section that provides post-installation information
 - hosts: kibana
+  tags:
+    - kibana
+    - elk
+
   post_tasks:
     - name: Where is Kibana located?
       debug:
         msg: "Kibana can be reached at http://{{hostvars['kibana']['ansible_host']}}"
 
 - hosts: jenkins_master
+  tags:
+    - jenkins_master
+
   post_tasks:
     - name: Where is Jenkins Master located?
       debug:


### PR DESCRIPTION
These changes automate the deployment of the Jenkins slave. When a new slave is spun up, it will be automatically added to the master, with all the appropriate credentials and information.
