### PR TITLE
Fix log message for http://{kibana,Jenkins Master}/

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -24,7 +24,7 @@
   post_tasks:
     - name: Where is Kibana located?
       debug:
-        msg: "Kibana can be reached at http://{{hostvars['kibana']['ansible_host']}}"
+        msg: "Kibana can be reached at http://{{hostvars['kibana']['ansible_host']}}:5601/"
 
 - hosts: jenkins_master
   tags:
@@ -33,4 +33,4 @@
   post_tasks:
     - name: Where is Jenkins Master located?
       debug:
-        msg: "Jenkins Master can be reached at http://{{hostvars['jenkins_master']['ansible_host']}}"
+        msg: "Jenkins Master can be reached at http://{{hostvars['jenkins_master']['ansible_host']}}:8080/"


### PR DESCRIPTION
Adding port number for each http://.../ with corresponding port
number (8080 for jenkins master, 5601 for kibana).
