### PR TITLE
Add geerlingguy.java in jenkins_slave

### DIFF
--- a/jenkins.yml
+++ b/jenkins.yml
@@ -226,6 +226,7 @@
   become: yes
   roles:
     - { role: 'franklinkim.sudo' }
+    - { role: 'geerlingguy.java' }
 
   vars_files:
     - "{{ inventory_dir  }}/../vars/main.yml"


### PR DESCRIPTION
At initial setup, jenkins slave cannot connect to master when
jenkins slave does not have java, hence add role into it.
