### PR TITLE
Add multiple node support for Jenkins slaves.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,14 +90,6 @@ be found in the _Access & Security_ section of the Horizon dashboard.
       - hostname: 127.0.0.1
         path: "{{ jenkins_master_results_directory }}"   # defined in vars/main.yml
 
-    slave_name: nfv-slave-01
-    slave_description: CIRA Testing Node
-    slave_remoteFS: /home/jenkins
-    slave_host: 10.10.0.101
-    slave_port: 22
-    slave_credentialsId: jenkins-credential
-    slave_label: cira
-
 ## Deployment
 
 ### Base Deployment
@@ -185,6 +177,13 @@ with the following template:
 
     [jenkins_slave]
     slave01 ansible_host=10.10.1.1 ansible_user=ansible
+ 
+    [jenkins_slave:vars]
+    slave_description=CIRA Testing Node
+    slave_remoteFS=/home/jenkins
+    slave_port=22
+    slave_credentialsId=jenkins-credential
+    slave_label=cira
 
 Add additional fields if necessary. It is assumed that the `ansible` user has
 been previously created, and that you can login either via SSH keys, or provide

--- a/jenkins.yml
+++ b/jenkins.yml
@@ -171,37 +171,42 @@
     - ~/.ansible/vars/cira_vars.yml
 
   tasks:
-    # TODO: This is kind of hacky since it doesn't deal with multiple jenkins
-    #       slaves. We'll need to circle back and make this deal with lists.
     - name: Check if our node already exists
-      ignore_errors: true
       command: >
         java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix | default('') }}/
-        get-node {{ slave_name }}
+        get-node {{ item }}
         --username {{ jenkins_admin_username }}
         --password {{ jenkins_admin_password }}
-      register: jenkins_cli_get_node
-      when: slave_name is defined
+      ignore_errors: true
+      register: jenkins_cli_get_nodes
+      with_items:
+         - "{{ groups['jenkins_slave'] }}"
 
     - name: Deploy template for Jenkins slave node
       template:
         src: jenkins_slave.j2
-        dest: /tmp/jenkins_slave_{{ slave_name }}.tmpl
-      when: jenkins_cli_get_node.stderr is defined and jenkins_cli_get_node.stderr != ""
+        dest: /tmp/jenkins_slave_{{ item.item }}.tmpl
+      when: "{{ item.rc != 0 }}"
+      with_items: 
+         - "{{ jenkins_cli_get_nodes.results }}"
 
     - name: Add Jenkins slave node to the master
       shell: >
         java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix | default('') }}/
-        create-node {{ slave_name }}
+        create-node {{ item.item }}
         --username {{ jenkins_admin_username }}
-        --password {{ jenkins_admin_password }} < /tmp/jenkins_slave_{{ slave_name }}.tmpl
-      when: jenkins_cli_get_node.stderr is defined and jenkins_cli_get_node.stderr != ""
+        --password {{ jenkins_admin_password }} < /tmp/jenkins_slave_{{ item.item }}.tmpl
+      when: "{{ item.rc != 0 }}"
+      with_items:
+         - "{{ jenkins_cli_get_nodes.results }}"
 
     - name: Remove template for Jenkins slave node
       file:
-        name: /tmp/jenkins_slave_{{ slave_name }}.tmpl
+        name: /tmp/jenkins_slave_{{ item }}.tmpl
         state: absent
-      when: slave_name is defined and jenkins_cli_get_node.stderr != ""
+      when: "{{ item.rc != 0 }}"
+      with_items:
+         - "{{ jenkins_cli_get_nodes.results }}"
 
 ######################
 # Deploy Jenkins jobs

--- a/jenkins.yml
+++ b/jenkins.yml
@@ -171,37 +171,43 @@
     - ~/.ansible/vars/cira_vars.yml
 
   tasks:
-    # TODO: This is kind of hacky since it doesn't deal with multiple jenkins
-    #       slaves. We'll need to circle back and make this deal with lists.
     - name: Check if our node already exists
-      ignore_errors: true
       command: >
         java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix | default('') }}/
-        get-node {{ slave_name }}
+        get-node {{ item }}
         --username {{ jenkins_admin_username }}
         --password {{ jenkins_admin_password }}
-      register: jenkins_cli_get_node
-      when: slave_name is defined
+      ignore_errors: true
+      register: jenkins_cli_get_nodes
+      changed_when: false
+      with_items:
+         - "{{ groups['jenkins_slave'] }}"
 
     - name: Deploy template for Jenkins slave node
       template:
         src: jenkins_slave.j2
-        dest: /tmp/jenkins_slave_{{ slave_name }}.tmpl
-      when: jenkins_cli_get_node.stderr is defined and jenkins_cli_get_node.stderr != ""
+        dest: /tmp/jenkins_slave_{{ item.item }}.tmpl
+      when: "{{ item.rc != 0 }}"
+      with_items:
+         - "{{ jenkins_cli_get_nodes.results }}"
 
     - name: Add Jenkins slave node to the master
       shell: >
         java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix | default('') }}/
-        create-node {{ slave_name }}
+        create-node {{ item.item }}
         --username {{ jenkins_admin_username }}
-        --password {{ jenkins_admin_password }} < /tmp/jenkins_slave_{{ slave_name }}.tmpl
-      when: jenkins_cli_get_node.stderr is defined and jenkins_cli_get_node.stderr != ""
+        --password {{ jenkins_admin_password }} < /tmp/jenkins_slave_{{ item.item }}.tmpl
+      when: "{{ item.rc != 0 }}"
+      with_items:
+         - "{{ jenkins_cli_get_nodes.results }}"
 
     - name: Remove template for Jenkins slave node
       file:
-        name: /tmp/jenkins_slave_{{ slave_name }}.tmpl
+        name: /tmp/jenkins_slave_{{ item }}.tmpl
         state: absent
-      when: slave_name is defined and jenkins_cli_get_node.stderr != ""
+      when: "{{ item.rc != 0 }}"
+      with_items:
+         - "{{ jenkins_cli_get_nodes.results }}"
 
 ######################
 # Deploy Jenkins jobs

--- a/templates/jenkins_slave.j2
+++ b/templates/jenkins_slave.j2
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <slave>
-  <name>{{ slave_name }}</name>
-  <description>{{ slave_description }}</description>
-  <remoteFS>{{ slave_remoteFS }}</remoteFS>
+  <name>{{ item.item }}</name>
+  <description>{{ hostvars[item.item].slave_description }}</description>
+  <remoteFS>{{ hostvars[item.item].slave_remoteFS }}</remoteFS>
   <numExecutors>1</numExecutors>
   <mode>NORMAL</mode>
   <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
   <launcher class="hudson.plugins.sshslaves.SSHLauncher" plugin="ssh-slaves@1.11">
-    <host>{{ slave_host }}</host>
-    <port>{{ slave_port }}</port>
-    <credentialsId>{{ slave_credentialsId }}</credentialsId>
+    <host>{{ hostvars[item.item].ansible_host }}</host>
+    <port>{{ hostvars[item.item].slave_port }}</port>
+    <credentialsId>{{ hostvars[item.item].slave_credentialsId }}</credentialsId>
     <maxNumRetries>0</maxNumRetries>
     <retryWaitTime>0</retryWaitTime>
   </launcher>
-  <label>{{ slave_label }}</label>
+  <label>{{ hostvars[item.item].slave_label }}</label>
   <nodeProperties/>
 </slave>


### PR DESCRIPTION
To support multiple node, the following changes is done in commit.
- move jenkins parameter from ~/.ansible/var/cira_vars.yml to
  inventry variables.
- use loop (i.e. with_items) to add nodes in jenkins
- modify templates to support multiple nodes
