### PR TITLE
Adjust Jenkins master to mirror oooq images

### DIFF
--- a/jenkins_jobs.yml
+++ b/jenkins_jobs.yml
@@ -39,6 +39,8 @@
         accept_hostkey: yes
       delegate_to: localhost
       changed_when: false
+      tags:
+        - clone_jobs
 
     - name: Create folder to store config
       file:

--- a/templates/jenkins_config/config.xml.j2
+++ b/templates/jenkins_config/config.xml.j2
@@ -2,7 +2,7 @@
 <hudson>
   <disabledAdministrativeMonitors/>
   <version>1.0</version>
-  <numExecutors>0</numExecutors>
+  <numExecutors>1</numExecutors>
   <mode>NORMAL</mode>
   <useSecurity>true</useSecurity>
   <authorizationStrategy class="hudson.security.FullControlOnceLoggedInAuthorizationStrategy">

--- a/templates/jenkins_master-vhost.conf.j2
+++ b/templates/jenkins_master-vhost.conf.j2
@@ -12,4 +12,9 @@ server {
         proxy_set_header    Host $host;
         proxy_cache_bypass  $http_upgrade;
     }
+
+    location /images {
+        root {{ jenkins_home }};
+        autoindex on;
+    }
 }


### PR DESCRIPTION
Also add the tag 'clone_jobs' so that you can skip the
job cloning, which is useful when you want to test custom
JJB changes.
