### PR TITLE
Externalize JJB sync from ansible-role-jenkins-job-builder

### DIFF
--- a/jenkins_jobs.yml
+++ b/jenkins_jobs.yml
@@ -71,8 +71,19 @@
     - { role: 'leifmadsen.jenkins-job-builder' }
 
   post_tasks:
+    - name: Synchronize JJB config to remote server
+      become: no
+      synchronize:
+        delete: yes
+        dest: "{{ jenkins_job_builder_file_jobs_dest }}"
+        perms: yes
+        src: "{{ jenkins_job_builder_file_jobs_src }}"
+      when: jenkins_job_builder_file_jobs_src != ""
+      notify:
+        - Check jenkins
+        - Reload jenkins-jobs
+
     - name: Results of JJB reload
       debug:
         var: reload_jenkins_jobs_result.stderr
       when: reload_jenkins_jobs_result is defined
-


### PR DESCRIPTION
This adds the synchronize module into the jenkins_jobs.yml playbook
instead of it being built into the ansible-role-jenkins-job-builder.

No functional change happens now, but this will provide us with more
flexibility what we're synchronizing to the remote location.
