### PR TITLE
Add EnvInject module to Jenkins

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -17,6 +17,7 @@ jenkins_plugins:
   - ssh-slaves
   - ws-cleanup
   - xtrigger
+  - envinject
 jenkins_scp_sites: []
 
 # JJB Configuration


### PR DESCRIPTION
This module is used by the JJB macros now to inject env
vars into the job run.
