### PR TITLE
Replace jenkins for stack in slave

### DIFF
--- a/jenkins.yml
+++ b/jenkins.yml
@@ -126,7 +126,7 @@
     sudo_defaults:
       - defaults: '!requiretty'
     sudo_users:
-      - name: 'jenkins'
+      - name: 'stack'
         nopasswd: yes
 
   pre_tasks:
@@ -135,10 +135,10 @@
         name: libselinux-python
         state: present
 
-    - name: Create jenkins user
+    - name: Create stack user
       user:
-        name: jenkins
-        comment: "Jenkins Slave User"
+        name: stack
+        comment: "Stack Slave User"
         generate_ssh_key: yes
 
   tasks:

--- a/jenkins_ssh.yml
+++ b/jenkins_ssh.yml
@@ -84,28 +84,28 @@
         # Skip ANSIBLE0015. Use of bare variable jenkins_master is correct.
         - skip_ansible_lint
 
-    - name: Get contents of jenkins public key
-      command: cat /home/jenkins/.ssh/id_rsa.pub
-      register: jenkins_slave_pub
+    - name: Get contents of stack public key
+      command: cat /home/stack/.ssh/id_rsa.pub
+      register: stack_slave_pub
       tags:
         # Skip ANSIBLE0012. We want to validate our public key is copied over.
         - skip_ansible_lint
 
     - name: Add authorized host keys to authorized_keys
-      become_user: jenkins
+      become_user: stack
       ignore_errors: yes
       authorized_key:
-        user: jenkins
+        user: stack
         key: "{{ item }}"
       with_items:
       - "{{ jenkins_master_pub }}"
-      - "{{ jenkins_slave_pub.stdout }}"
+      - "{{ stack_slave_pub.stdout }}"
 
-    - name: Add jenkins public key to local root user
+    - name: Add stack public key to local root user
       become: yes
       authorized_key:
         user: root
-        key: "{{ jenkins_slave_pub.stdout }}"
+        key: "{{ stack_slave_pub.stdout }}"
 
     - name: Get SSH fingerprint of slave
       shell: ssh-keyscan -4 -t ecdsa-sha2-nistp256 $HOSTNAME


### PR DESCRIPTION
We need to run tripleo-quickstart jobs as stack
user in order to execute properly.
