### PR TITLE
Inital support for docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.retry
 hosts/
 !hosts/localhost
+!hosts/containers
 roles/
 inventory
 files/jobs/

--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ that directory (adjust to your own cloud connection):
                 password: cloud_pass
                 project_name: "My Cloud Project"
 
+## Docker
+
+ansible-cira also supports docker container instead of OpenStack and Vagrant.
+In order to use docker, you need to insatll [docker-compose](https://docs.docker.com/compose/).
+
+At present, we tested in docker-compose 1.7.1, build 6c289830.
+
 ## Overrides / Private Info
 
 There may be some variables you don't want to expose into a Git repo. You can
@@ -142,6 +149,46 @@ Format is the following (see _Example Variable Override File_ for an example):
         user: jenkins1
         keyfile: abc
         path: /test/path
+
+## Base Deployment (docker)
+
+Start by creating `hosts/containers` (or similar) and add your baremetal machine
+with the following template:
+
+    jenkins_master
+    logstash
+    elasticsearch
+    kibana
+
+These name (e.g. jenkins_master, logstash...) should be matched with container name in cira-container.yml.
+
+If you need to add jenkins slaves (baremetal), add slave information in 'hosts/containers'
+as following (please add 'ansible_connection=ssh').
+
+    [jenkins_slave]
+    slave01 ansible_connection=ssh ansible_host=10.10.1.1 ansible_user=ansible
+
+    [jenkins_slave:vars]
+    slave_description=CIRA Testing Node
+    slave_remoteFS=/home/stack
+    slave_port=22
+    slave_credentialsId=jenkins-credential
+    slave_label=cira
+
+Then, you can run following commands to setup containers and to setup cira environments.
+
+    $ docker-compose up -d
+    $ ansible-playbook site.yml -vvvv -i hosts/containers -e use_openstack_deploy=false -e deploy_type='docker' -c docker
+
+After you finish, you can stop these containers and restart them.
+
+    $ docker-compose stop
+    (To restart them)
+    $ docker-compose restart
+
+The following commands deletes container.
+
+    $ docker-compose down
 
 ### Jenkins Slave Installation
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Quickstart](https://github.com/openstack/tripleo-quickstart).
 
 # Requirements
 
-There are two ways to install CIRA. You deploy locally into a development
-environment using Vagrant, you can deploy locally into a docker container
+There are multiple ways to install CIRA. You deploy locally into a development
+environment using Vagrant; you can deploy locally into a Docker container
 or you can deploy to an OpenStack instance. Below you will find the list of 
 requirements for each of the deployment scenarios.
 
@@ -31,11 +31,11 @@ available at https://github.com/vagrant-libvirt/vagrant-libvirt
 
 ## Docker
 
-ansible-cira also supports docker container instead of OpenStack and Vagrant.
-In order to use docker, you need to insatll 
+In addition to support OpenStack and Vagrant deployments, ansible-cira also
+utilize Docker containers. In order to use Docker, you need to install
 [docker-compose](https://docs.docker.com/compose/).
 
-At present, we tested in docker-compose 1.7.1, build 6c289830.
+At present, we tested using docker-compose 1.7.1, build 6c289830.
 
 ## OpenStack
 
@@ -153,11 +153,11 @@ with the following template:
     elasticsearch
     kibana
 
-These name (e.g. jenkins_master, logstash...) should be matched with container name in cira-container.yml.
+These names (e.g. jenkins_master, logstash, etc) should match the names as defined in 'docker-compose.yml'.
 
-### Adding baremetal slaves into docker deployment
+### Adding baremetal slaves to a Docker deployment
 If you need to add jenkins slaves (baremetal), add slave information in 'hosts/containers'
-as following (please add 'ansible_connection=ssh').
+as the following (be sure to add `ansible_connection=ssh` as well).
 
     [jenkins_slave]
     slave01 ansible_connection=ssh ansible_host=10.10.1.1 ansible_user=ansible
@@ -169,8 +169,8 @@ as following (please add 'ansible_connection=ssh').
     slave_credentialsId=stack-credential
     slave_label=cira
 
-### Running container and start provisioning
-Then, you can run following commands to setup containers and to setup cira environments.
+### Running containers and start provisioning
+Then, you can run the following commands to setup containers and to setup the CIRA environment.
 
     $ docker-compose up -d
     $ ansible-playbook site.yml -vvvv -i hosts/containers \
@@ -182,7 +182,7 @@ After you finish, you can stop these containers and restart them.
     (To restart them)
     $ docker-compose restart
 
-The following commands deletes container.
+The following commands delete the containers.
 
     $ docker-compose down
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+version: '2'
+
+# docker-compose file to launch jenkins_master/ELK stack instead of VM.
+services:
+  jenkins_master:
+    build: 
+      context: ./dockerfiles 
+      dockerfile: centos7_base
+    container_name: jenkins_master
+    security_opt:
+      - seccomp:unconfined
+    volumes:
+      - /run
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    entrypoint: /sbin/init
+
+  logstash:
+    build: 
+      context: ./dockerfiles 
+      dockerfile: centos7_base
+    container_name: logstash
+    security_opt:
+      - seccomp:unconfined
+    volumes:
+      - /run
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    entrypoint: /sbin/init
+
+  elasticsearch:
+    build: 
+      context: ./dockerfiles 
+      dockerfile: centos7_base
+    container_name: elasticsearch
+    security_opt:
+      - seccomp:unconfined
+    volumes:
+      - /run
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    entrypoint: /sbin/init
+
+  kibana:
+    build: 
+      context: ./dockerfiles 
+      dockerfile: centos7_base
+    container_name: kibana
+    security_opt:
+      - seccomp:unconfined
+    volumes:
+      - /run
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    entrypoint: /sbin/init

--- a/dockerfiles/centos7_base
+++ b/dockerfiles/centos7_base
@@ -1,0 +1,6 @@
+FROM centos:centos7
+
+RUN yum update -y && yum install -y sudo iproute epel-release && \
+	yum install -y openssh openssh-server openssh-clients && \
+	yum install -y python-pip && \
+	sed -ie 's/requiretty/!requiretty/g' /etc/sudoers

--- a/elk.yml
+++ b/elk.yml
@@ -43,9 +43,13 @@
       selinux:
         policy: targeted
         state: enforcing
+      when: ansible_connection != 'docker'
+      #when: deploy_type is not defined or deploy_type != 'docker'
 
     - name: SELinux -- Enable httpd_can_network_connect
       seboolean:
         name: httpd_can_network_connect
         state: yes
         persistent: yes
+      when: ansible_connection != 'docker'
+      #when: deploy_type is not defined or deploy_type != 'docker'

--- a/hosts/containers
+++ b/hosts/containers
@@ -1,0 +1,4 @@
+jenkins_master
+logstash
+elasticsearch
+kibana

--- a/jenkins.yml
+++ b/jenkins.yml
@@ -20,6 +20,22 @@
     sudo_defaults:
       - defaults: '!requiretty'
 
+  pre_tasks:
+    - name: Add jenkins service unit to systemd in case of docker.
+      copy:
+        dest: /etc/systemd/system/jenkins.service
+        content: |
+            [Unit]
+            Description=Jenkins Daemon
+
+            [Service]
+            ExecStart=/usr/bin/java -Dcom.sun.akuma.Daemon=daemonized -Djava.awt.headless=true -Djenkins.install.runSetupWizard=false -DJENKINS_HOME=/var/lib/jenkins -jar /usr/lib/jenkins/jenkins.war --logfile=/var/log/jenkins/jenkins.log --webroot=/var/cache/jenkins/war --daemon --httpPort=8080 --debug=5 --handlerCountMax=100 --handlerCountMaxIdle=20 --prefix=
+            User=jenkins
+
+            [Install]
+            WantedBy=multi-user.target
+      when: deploy_type is defined and deploy_type == 'docker'
+
   tasks:
     - name: Set facts for later use
       set_fact:
@@ -29,6 +45,13 @@
         jenkins_url_prefix: "{{ jenkins_url_prefix }}"
         jenkins_admin_username: "{{ jenkins_admin_username }}"
         jenkins_admin_password: "{{ jenkins_admin_password }}"
+
+# In case of docker, jenkins is managed under systemd unit (see above)
+    - name: jenkins init script is removed in case of docker
+      file:
+        path: /etc/init.d/jenkins
+        state: absent
+      when: deploy_type is defined and deploy_type == 'docker'
 
   post_tasks:
     # Operating system configuration and setup
@@ -56,12 +79,14 @@
       selinux:
         policy: targeted
         state: enforcing
+      when: ansible_connection != 'docker'
 
     - name: SELinux -- Enable httpd_can_network_connect
       seboolean:
         name: httpd_can_network_connect
         state: yes
         persistent: yes
+      when: ansible_connection != 'docker'
 
     # Copy in configuration for Nginx web proxy fronting Jenkins web UI
     - name: Copy Jenkins Nginx Configuration

--- a/jenkins.yml
+++ b/jenkins.yml
@@ -24,18 +24,12 @@
 
   pre_tasks:
     - name: Add jenkins service unit to systemd in case of docker.
-      copy:
+      template:
+        src: jenkins_systemd.j2
         dest: /etc/systemd/system/jenkins.service
-        content: |
-            [Unit]
-            Description=Jenkins Daemon
-
-            [Service]
-            ExecStart=/usr/bin/java -Dcom.sun.akuma.Daemon=daemonized -Djava.awt.headless=true -Djenkins.install.runSetupWizard=false -DJENKINS_HOME=/var/lib/jenkins -jar /usr/lib/jenkins/jenkins.war --logfile=/var/log/jenkins/jenkins.log --webroot=/var/cache/jenkins/war --daemon --httpPort=8080 --debug=5 --handlerCountMax=100 --handlerCountMaxIdle=20 --prefix=
-            User=jenkins
-
-            [Install]
-            WantedBy=multi-user.target
+        owner: root
+        group: root
+        mode: "0655"
       when: deploy_type is defined and deploy_type == 'docker'
 
   tasks:

--- a/jenkins_jobs.yml
+++ b/jenkins_jobs.yml
@@ -66,6 +66,13 @@
         src: "./files/nfv_jobs_config/"
         dest: "{{ jenkins_job_config_file_src }}"
         archive: yes
+      when: deploy_type is not defined or deploy_type != 'docker'
+
+    - name: Synchronize job config to remote server (docker)
+      copy:
+        src: "{{ jenkins_job_config_file_src }}"
+        dest: "{{ jenkins_job_config_file_dest }}"
+      when: deploy_type is defined and deploy_type == 'docker'
 
   roles:
     - { role: 'leifmadsen.jenkins-job-builder' }
@@ -78,13 +85,34 @@
         dest: "{{ jenkins_job_builder_file_jobs_dest }}"
         perms: yes
         src: "{{ item }}"
-      when: jenkins_job_builder_file_jobs_src != ""
+      when: jenkins_job_builder_file_jobs_src != "" and
+            (deploy_type is not defined or deploy_type != 'docker')
       with_items: "{{ jenkins_job_builder_file_jobs_src }}"
       notify:
         - Check jenkins
         - Reload jenkins-jobs
       tags:
         - sync_jobs
+
+    - name: prepare Synchronize JJB config to remote server (docker)
+      file:
+        path: "{{ jenkins_job_builder_file_jobs_dest }}"
+        group: jenkins
+        owner: jenkins
+      when: jenkins_job_builder_file_jobs_src != "" and
+            (deploy_type is defined and deploy_type == 'docker')
+
+    - name: Synchronize JJB config to remote server (docker)
+      become: true
+      become_user: jenkins
+      copy:
+        dest: "{{ jenkins_job_builder_file_jobs_dest }}"
+        src: "{{ item }}"
+      when: jenkins_job_builder_file_jobs_src != "" and
+            (deploy_type is defined and deploy_type == 'docker')
+      with_items: "{{ jenkins_job_builder_file_jobs_src }}"
+      notify:
+        - Check jenkins
 
     - name: Results of JJB reload
       debug:

--- a/site.yml
+++ b/site.yml
@@ -24,7 +24,7 @@
   post_tasks:
     - name: Where is Kibana located?
       debug:
-        msg: "Kibana can be reached at http://{{hostvars['kibana']['ansible_host']}}:5601/"
+        msg: "Kibana can be reached at http://{{hostvars[inventory_hostname]['ansible_default_ipv4']['address']}}:5601/"
 
 - hosts: jenkins_master
   tags:
@@ -33,4 +33,4 @@
   post_tasks:
     - name: Where is Jenkins Master located?
       debug:
-        msg: "Jenkins Master can be reached at http://{{hostvars['jenkins_master']['ansible_host']}}:8080/"
+        msg: "Jenkins Master can be reached at http://{{hostvars[inventory_hostname]['ansible_default_ipv4']['address']}}:8080/"

--- a/templates/jenkins_systemd.j2
+++ b/templates/jenkins_systemd.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Jenkins Daemon
+
+[Service]
+ExecStart=/usr/bin/java -Dcom.sun.akuma.Daemon=daemonized -Djava.awt.headless=true -Djenkins.install.runSetupWizard=false -DJENKINS_HOME=/var/lib/jenkins -jar /usr/lib/jenkins/jenkins.war --logfile=/var/log/jenkins/jenkins.log --webroot=/var/cache/jenkins/war --daemon --httpPort=8080 --debug=5 --handlerCountMax=100 --handlerCountMaxIdle=20 --prefix=
+User=jenkins
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This patch supports docker container for jenkins_master/ELK in cira, Issue #48 .
This change introduce docker-compose.yml to run docker container and deploy_type to identify which platform is target (docker, vagrant or OpenStack).

This changes has been tested the following platforms:
- CentOS (with docker container)
- Fedora (with docker container)
- CentOS (with OpenStack, for regression)
