### PR TITLE
Support dovetail of OPNFV in CIRA.

### DIFF
--- a/docker-compose-dovetail.yml
+++ b/docker-compose-dovetail.yml
@@ -1,0 +1,63 @@
+version: '2'
+
+# docker-compose file to launch jenkins_master/ELK stack instead of VM, 
+# with dovetail project container from OPNFV.
+services:
+  jenkins_master:
+    build: 
+      context: ./dockerfiles 
+      dockerfile: centos7_base
+    container_name: jenkins_master
+    security_opt:
+      - seccomp:unconfined
+    volumes:
+      - /run
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    entrypoint: /sbin/init
+
+  logstash:
+    build: 
+      context: ./dockerfiles 
+      dockerfile: centos7_base
+    container_name: logstash
+    security_opt:
+      - seccomp:unconfined
+    volumes:
+      - /run
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    entrypoint: /sbin/init
+
+  elasticsearch:
+    build: 
+      context: ./dockerfiles 
+      dockerfile: centos7_base
+    container_name: elasticsearch
+    security_opt:
+      - seccomp:unconfined
+    volumes:
+      - /run
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    entrypoint: /sbin/init
+
+  kibana:
+    build: 
+      context: ./dockerfiles 
+      dockerfile: centos7_base
+    container_name: kibana
+    security_opt:
+      - seccomp:unconfined
+    volumes:
+      - /run
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    entrypoint: /sbin/init
+
+  dovetail:
+    build: 
+      context: ./dockerfiles 
+      dockerfile: centos7_dovetail
+    container_name: dovetail
+    security_opt:
+      - seccomp:unconfined
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    entrypoint: /sbin/init

--- a/dockerfiles/centos7_dovetail
+++ b/dockerfiles/centos7_dovetail
@@ -1,0 +1,19 @@
+FROM centos:7
+
+ADD files/docker.repo.centos /etc/yum.repos.d/docker.repo
+
+ENV HOME /home/opnfv
+ENV REPOS_DIR ${HOME}/dovetail
+WORKDIR /home/opnfv
+
+RUN yum update -y && \
+    yum install -y sudo iproute epel-release && \
+    yum install -y openssh openssh-server openssh-clients && \
+    yum install -y python-pip git docker-engine-1.9.1-1.el7.centos && \
+    sed -ie 's/requiretty/!requiretty/g' /etc/sudoers && \
+    pip install pyyaml click jinja2 && \
+    git config --global http.sslVerify false && \
+    git clone https://gerrit.opnfv.org/gerrit/dovetail.git ${REPOS_DIR} && \
+    mkdir -p ${REPOS_DIR}/results
+
+WORKDIR ${REPOS_DIR}/dovetail


### PR DESCRIPTION
Add docker-compose-dovetail.yml for containers with dovetail,
OPNFV test driver for OPNFV trademark. centos7_dovetail is newly
introduced to create dovetail container based on CentOS.

Signed-off-by: Tomofumi Hayashi <tohayash@redhat.com>