### PR TITLE
[enhancement] addresses #51 by adding lint for dockerfiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
     - sudo apt-get install -qq python-apt
     - mkdir -p ~/.ansible/vars
     - touch ~/.ansible/vars/cira_vars.yml
+    - sudo docker pull projectatomic/dockerfile-lint
 install:
     - pip install ansible
     - pip install ansible-lint
@@ -16,3 +17,4 @@ script:
     - ansible-playbook --syntax-check openstack.yml
     - ansible-playbook --syntax-check site.yml
     - ansible-lint --exclude=roles site.yml
+    - sudo docker run -it --rm --privileged -v `pwd`:/root/ projectatomic/dockerfile-lint dockerfile_lint --permissive -f dockerfiles/*

--- a/dockerfiles/centos7_base
+++ b/dockerfiles/centos7_base
@@ -1,6 +1,10 @@
 FROM centos:centos7
 
+LABEL Name="CIRA" \
+      Version="{placeholder}"
+
 RUN yum update -y && yum install -y sudo iproute epel-release && \
-	yum install -y openssh openssh-server openssh-clients && \
-	yum install -y python-pip && \
-	sed -ie 's/requiretty/!requiretty/g' /etc/sudoers
+    yum install -y openssh openssh-server openssh-clients && \
+    yum install -y python-pip && \
+    sed -ie 's/requiretty/!requiretty/g' /etc/sudoers && \
+    yum -y clean all


### PR DESCRIPTION
Adds a dockerfile_lint check for all files in the `./dockerfiles/` dir, and mildly changes the dockerfile to pass checks especially as related to meta data (specifically the `LABEL`s). This check cannot be overridden that I have seen.