### PR TITLE
Add ability to pre-provision in Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ inventory
 files/
 !files/filebeat.yml
 .vagrant/
+vagrant/

--- a/README.md
+++ b/README.md
@@ -160,6 +160,31 @@ configuration to the virtual machines. The deployment uses the built in default
 networking configuration that Vagrant instantiates. At the end of the run, the
 web interface addresses for Jenkins and Kibana will be displayed.
 
+### Vagrant Pre-Configuration Customization
+
+You can add separate pre-configuration to your Vagrant nodes by providing an
+override file in the `vagrant/` directory (you'll need to create it). You can
+then add additional configuration information to Vagrant for those nodes such
+as additional provisioner or network configuration.
+
+For example, you could add a public network to your Jenkins master so that you
+can deploy virtual machines easily with Vagrant against libvirt, then access
+those nodes remotely.
+
+To do this, create the `vagrant/` directory, and then create the
+`Vagrantfile.jenkins_master` and add the following block of data:
+
+```
+    jenkins_master.vm.network :public_network,
+      :dev => "br0",
+      :mode => "bridge",
+      :type => "bridge"
+
+    jenkins_master.vm.provision "shell",
+      inline: 'sudo nmcli con mod "Wired connection 1" ipv4.route-metric 400 ; sudo nmcli con down "Wired connection 1" ; sudo nmcli con up "Wired connection 1" ;\
+               sudo nmcli con add type vlan ifname eth1.4 con-name eth1.4 dev eth1 id 4'
+```
+
 ## Base Deployment (docker)
 
 Start by creating `hosts/containers` (or similar) and add your baremetal machine

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,15 +2,6 @@
 # vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
-  config.vm.define :jenkins_master do |jenkins_master|
-    jenkins_master.vm.box = "centos/7"
-    jenkins_master.vm.provider :libvirt do |domain|
-      domain.machine_arch = 'x86_64'
-      domain.cpu_mode = 'host-passthrough'
-      domain.memory = "2048"
-    end
-  end
-
   config.vm.define :elasticsearch do |elasticsearch|
     elasticsearch.vm.box = "centos/7"
     elasticsearch.vm.provider :libvirt do |domain|
@@ -18,6 +9,10 @@ Vagrant.configure(2) do |config|
       domain.cpu_mode = 'host-passthrough'
       domain.memory = "1024"
     end
+
+    # load in custom configuration for elasticsearch if it exists
+    elasticsearch_vagrantfile = File.expand_path('../vagrant/Vagrantfile.elasticsearch',__FILE__)
+    eval File.read(elasticsearch_vagrantfile) if File.exists?(elasticsearch_vagrantfile)
   end
 
   config.vm.define :logstash do |logstash|
@@ -27,6 +22,10 @@ Vagrant.configure(2) do |config|
       domain.cpu_mode = 'host-passthrough'
       domain.memory = "1024"
     end
+
+    # load in custom configuration for logstash if it exists
+    logstash_vagrantfile = File.expand_path('../vagrant/Vagrantfile.logstash',__FILE__)
+    eval File.read(logstash_vagrantfile) if File.exists?(logstash_vagrantfile)
   end
 
   config.vm.define :kibana do |kibana|
@@ -36,17 +35,35 @@ Vagrant.configure(2) do |config|
       domain.cpu_mode = 'host-passthrough'
       domain.memory = "2048"
     end
+
+    # load in custom configuration for kibana if it exists
+    kibana_vagrantfile = File.expand_path('../vagrant/Vagrantfile.kibana',__FILE__)
+    eval File.read(kibana_vagrantfile) if File.exists?(kibana_vagrantfile)
   end
 
-  config.vm.provision :ansible do |ansible|
-    ansible.extra_vars = {
-      use_openstack_deploy: false,
-      vars_files_relative: "../../../.."    # this sets the relative path from
-                                            # from the inventory file to the
-                                            # vars/ directory.
-    }
-    ansible.limit = "all"
-    ansible.skip_tags = "jenkins_slave"
-    ansible.playbook = 'site.yml'
+  config.vm.define :jenkins_master do |jenkins_master|
+    jenkins_master.vm.box = "centos/7"
+
+    jenkins_master.vm.provider :libvirt do |domain|
+      domain.machine_arch = 'x86_64'
+      domain.cpu_mode = 'host-passthrough'
+      domain.memory = "2048"
+    end
+
+    # load in custom configuration for jenkins_master if it exists
+    jenkins_master_vagrantfile = File.expand_path('../vagrant/Vagrantfile.jenkins_master',__FILE__)
+    eval File.read(jenkins_master_vagrantfile) if File.exists?(jenkins_master_vagrantfile)
+
+    jenkins_master.vm.provision "ansible", run: "never" do |ansible|
+      ansible.extra_vars = {
+        use_openstack_deploy: false,
+        vars_files_relative: "../../../.."    # this sets the relative path from
+                                              # from the inventory file to the
+                                              # vars/ directory.
+      }
+      ansible.limit = "all"
+      ansible.skip_tags = "jenkins_slave"
+      ansible.playbook = 'site.yml'
+    end
   end
 end

--- a/elk.yml
+++ b/elk.yml
@@ -8,6 +8,7 @@
 
   vars_files:
     - "{{ inventory_dir  }}/{{ vars_files_relative }}/vars/main.yml"
+    - ~/.ansible/vars/toad_vars.yml
 
   roles:
     - { role: 'geerlingguy.repo-epel' }
@@ -21,6 +22,7 @@
 
   vars_files:
     - "{{ inventory_dir  }}/{{ vars_files_relative }}/vars/main.yml"
+    - ~/.ansible/vars/toad_vars.yml
 
   roles:
     - { role: 'geerlingguy.repo-epel' }
@@ -35,6 +37,7 @@
 
   vars_files:
     - "{{ inventory_dir  }}/{{ vars_files_relative }}/vars/main.yml"
+    - ~/.ansible/vars/toad_vars.yml
 
   roles:
     - { role: 'geerlingguy.repo-epel' }

--- a/site.yml
+++ b/site.yml
@@ -11,20 +11,27 @@
 
 # Include the ELK stack playbook
 - include: elk.yml
+  when: elk_deployed
 
 # Include FileBeat setup
 - include: filebeat.yml
+  when: filebeat_deployed
 
 # Section that provides post-installation information
 - hosts: kibana
+  vars_files:
+    - ~/.ansible/vars/toad_vars.yml
+
   tags:
     - kibana
     - elk
 
   post_tasks:
     - name: Where is Kibana located?
+
       debug:
         msg: "Kibana can be reached at http://{{hostvars[inventory_hostname]['ansible_default_ipv4']['address']}}:5601/"
+      when: elk_deployed
 
 - hosts: jenkins_master
   tags:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -41,6 +41,9 @@ jenkins_job_config_file_src: "./files/job-configs/"
 jenkins_job_config_file_dest: "/var/lib/jenkins/userContent/config"
 
 
+# Enable ELK stack?
+elk_deployed: true
+
 # Logstash Configuration
 logstash_configuration_files:
   - 03-beats.conf
@@ -55,6 +58,7 @@ elasticsearch_url: http://{{ elasticsearch_network_address }}:{{ elasticsearch_h
 elasticsearch_network_host: 0.0.0.0
 
 # FileBeat configuration
+filebeat_deployed: true
 filebeat_user: root
 filebeat_group: root
 filebeat_create_user: false


### PR DESCRIPTION
I had a need to add some network configuration changes to my nodes
while spinning up VMs with Vagrant. This commit adds the ability to
add custom changes to your node block configuration by creating a vagrant/
directory and adding a Vagrantfile.<node_name> file to that directory.

You can then add your own custom configuration options which will run
before the main Ansible provisioner. The use case I'm solving for is when
I want to add a bridged (public) interface to a Vagrant node and then
configure a tagged VLAN interface before doing the main provisioning
with Ansible.