### PR TITLE
Fix FileBeat installation issues

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -20,6 +20,7 @@
 # Section that provides post-installation information
 - hosts: kibana
   vars_files:
+    - "{{ inventory_dir  }}/{{ vars_files_relative }}/vars/main.yml"
     - ~/.ansible/vars/toad_vars.yml
 
   tags:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,6 +6,7 @@ jenkins_master_server_name: ci.example.tld
 jenkins_master_nginx_access_log: /var/log/nginx/jenkins.access.log
 jenkins_master_ssh_directory: /var/lib/jenkins/.ssh/
 jenkins_master_results_directory: /srv/static/
+jenkins_version: 2.32
 jenkins_repo_url: http://pkg.jenkins-ci.org/redhat-stable/jenkins.repo
 jenkins_plugins:
   - build-timeout
@@ -69,7 +70,7 @@ filebeat_deployed: true
 filebeat_user: root
 filebeat_group: root
 filebeat_create_user: false
-filebeat_version: 1.2.3
+filebeat_version: 5.x
 filebeat_start_at_boot: true
 filebeat_config_file: /etc/filebeat/filebeat.yml
 filebeat_config_prospectors: |


### PR DESCRIPTION
This fix changes the 'filebeat version' to be 5.x.

The upstream repository path changed and now access to the
1.x versions seems to be gone. I don't love this fix but
it'll allow things to pass and install. I haven't done any
testing with FileBeat in a bit, so will need to revisit.

I plan to add changes to upstream torian.filebeat ansible
role so that I can lock to a specific FileBeat version in
the 5.x branch.