### PR TITLE
Two fixes: update rhel mirror, isolate rhn subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,6 @@ Jenkins slaves via the `[jenkins_slave]` and `[jenkins_slave:vars]` headers.
 * slave_credentialsId
 * slave_label
 
-On a Red Hat system, subscription of slaves can be managed automatically
-if you pass the right credentials:
-* rhn_subscription_username
-* rhn_subscription_password
-* rhn_subscription_pool_id
-
 ## Example Override Variable File
 Many of the values can be found in your OpenStack RC file, which can typically
 be found in the _Access & Security_ section of the Horizon dashboard.
@@ -360,6 +354,19 @@ Each environment needs to have the following content:
   the IPMI address/user/password is required, as well as the provisioning macs.
 - net_environment.yml: TripleO environment file that will be used. You can specify here all
   the typical TripleO settings that need to be customized.
+
+## RHN subscription
+
+On a Red Hat system, subscription of slaves can be managed automatically
+if you pass the right credentials:
+* rhn_subscription_username
+* rhn_subscription_password
+* rhn_subscription_pool_id
+
+Subscription can be managed automatically either on master or slaves, with the
+flags:
+* master_subscribe_rhn
+* slave_subscribe_rhn
 
 [toad_workflow]: https://raw.githubusercontent.com/redhat-nfvpe/toad/master/TOAD_Workflow.png
 

--- a/jenkins.yml
+++ b/jenkins.yml
@@ -138,6 +138,9 @@
         group: jenkins
         mode: "0755"
 
+    - include: rhel_register.yml
+      when: ansible_os_family == "RedHat" and master_subscribe_rhn|bool == True
+
     - include: rhel_mirror_sync.yml
       when: ansible_os_family == "RedHat" and master_mirror_sync|bool == true
 
@@ -198,36 +201,8 @@
           mode: "0755"
       become: true
 
-    - block:
-        - name: Unsubscribe previous system
-          redhat_subscription:
-              state: absent
-          ignore_errors: true
-
-        - name: Cleanup previous systems
-          command: "subscription-manager remove --all"
-
-        - name: Subscribe for RedHat systems
-          redhat_subscription:
-              state: present
-              username: "{{ rhn_subscription_username }}"
-              password: "{{ rhn_subscription_password }}"
-              pool: "{{ rhn_subscription_pool_id }}"
-
-        - name: Attach to the desired pool
-          command: "subscription-manager attach --pool={{ rhn_subscription_pool_id }}"
-          when: rhn_subscription_pool_id is defined
-
-        - name: Unsubscribe to previous repos
-          command: "subscription-manager repos --disable=*"
-          when: rhn_repos|length > 0
-
-        - name: Subscribe to the list of desired repos
-          command: "subscription-manager repos --enable {{ item }}"
-          with_items: "{{ rhn_repos }}"
-          when: rhn_repos|length > 0
-      become: true
-      when: ansible_os_family == "RedHat" and rhn_subscription_username is defined and rhn_subscription_password is defined
+    - include: rhel_register.yml
+      when: ansible_os_family == "RedHat" and slave_subscribe_rhn|bool == True
 
     - include: rhel_mirror_sync.yml
       when: ansible_os_family == "RedHat" and slave_mirror_sync|bool == true

--- a/rhel_mirror_sync.yml
+++ b/rhel_mirror_sync.yml
@@ -44,25 +44,25 @@
       when: iptables_service_status.stdout != 'active'
 
     - name: Check if repo already exists
-      stat: path=/tmp/osp_repo
+      stat: path=/var/ftp/pub/osp_repo
       register: repo_already_exists
 
     - name: Create temporary directory for mirror
       file:
-          path: /tmp/osp_repo
+          path: /var/ftp/pub/osp_repo
           state: directory
           mode: "0755"
       when: repo_already_exists.stat.exists == False
 
     - name: Mirror repository locally
-      shell: "reposync -l -n -p /tmp/osp_repo/ > /dev/null"
+      shell: "reposync -l -n -p /var/ftp/pub/osp_repo/ > /dev/null"
       when: repo_already_exists.stat.exists == False
 
     - name: Create repositories from local mirror
-      shell: "for DIR in `find /tmp/osp_repo  -maxdepth 1 -mindepth 1 -type d`; do createrepo $DIR; done; > /dev/null"
+      shell: "for DIR in `find /var/ftp/pub/osp_repo  -maxdepth 1 -mindepth 1 -type d`; do createrepo $DIR; done; > /dev/null"
       when: repo_already_exists.stat.exists == False
 
     - name: Execute repository creation script
-      script: "./scripts/create_repo.sh /tmp osp_repo"
+      script: "./scripts/create_repo.sh osp_repo"
   become: true
 

--- a/rhel_register.yml
+++ b/rhel_register.yml
@@ -1,0 +1,39 @@
+- name: fail if no credentials are provided
+  fail:
+      msg: "Please define rhn_subscription_username, rhn_subscription_password and rhn_subscription_pool_id to enroll your system"
+  when: rhn_subscription_username is undefined or rhn_subscription_username|bool == false or
+        rhn_subscription_password is undefined or rhn_subscription_password|bool == false or
+        rhn_subscription_pool_id is undefine or rhn_subscription_password|bool == false
+
+- name: Unsubscribe previous system
+  redhat_subscription:
+      state: absent
+      ignore_errors: true
+  become: true
+
+- name: Cleanup previous systems
+  command: "subscription-manager remove --all"
+  become: true
+
+- name: Subscribe for RedHat systems
+  redhat_subscription:
+      state: present
+      username: "{{ rhn_subscription_username }}"
+      password: "{{ rhn_subscription_password }}"
+      pool: "{{ rhn_subscription_pool_id }}"
+  become: true
+
+- name: Attach to the desired pool
+  command: "subscription-manager attach --pool={{ rhn_subscription_pool_id }}"
+  become: true
+
+- name: Unsubscribe to previous repos
+  command: "subscription-manager repos --disable=*"
+  when: rhn_repos|length > 0
+  become: true
+
+- name: Subscribe to the list of desired repos
+  command: "subscription-manager repos --enable {{ item }}"
+  with_items: "{{ rhn_repos }}"
+  when: rhn_repos|length > 0
+  become: true

--- a/rhel_register.yml
+++ b/rhel_register.yml
@@ -23,10 +23,12 @@
       password: "{{ rhn_subscription_password }}"
       pool: "{{ rhn_subscription_pool_id }}"
   become: true
+  changed_when: false
 
 - name: Attach to the desired pool
   command: "subscription-manager attach --pool={{ rhn_subscription_pool_id }}"
   become: true
+  changed_when: false
 
 - name: Unsubscribe to previous repos
   command: "subscription-manager repos --disable=*"

--- a/rhel_register.yml
+++ b/rhel_register.yml
@@ -13,6 +13,7 @@
 
 - name: Cleanup previous systems
   command: "subscription-manager remove --all"
+  changed_when: false
   become: true
 
 - name: Subscribe for RedHat systems

--- a/scripts/create_repo.sh
+++ b/scripts/create_repo.sh
@@ -1,11 +1,9 @@
-ADDRESS=$1
-REPONAME=$2
+REPONAME=$1
 PUBLIC_ADDRESS=$(hostname --ip-address)
 REPOPATH="/var/ftp/pub/"
 REPOFILE="${REPOPATH}/${REPONAME}/osp.repo"
 
 mkdir -p $REPOPATH
-cp -R "${ADDRESS}/${REPONAME}/" ${REPOPATH}
 rm $REPOFILE 2> /dev/null
 touch $REPOFILE
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -101,6 +101,9 @@ filebeat_config_logging: |
       name: mybeat.log
       keepfiles: 7
 
+# RHN subscription
+master_subscribe_rhn: false
+slave_subscribe_rhn: false
 rhn_repos:
   - rhel-7-server-rpms
   - rhel-7-server-extras-rpms


### PR DESCRIPTION
Instead of relying on tmp directory and copying the repo after
it, use directly the ftp path. This will make easier to manage
the repo (that is a large size one), on systems with volumes,
not needing an extra volume for tmp.