### PR TITLE
Reload jenkins jobs after synchronizing JJB config

### DIFF
--- a/jenkins_jobs.yml
+++ b/jenkins_jobs.yml
@@ -155,6 +155,7 @@
       with_items: "{{ jenkins_job_builder_file_jobs_src }}"
       notify:
         - Check jenkins
+        - Reload jenkins-jobs
 
     - name: Results of JJB reload
       debug:


### PR DESCRIPTION
JJB files are not loaded when using docker installation method, adding 'Reload' notification after synchronizing JJB config.

Signed-off-by: zshi <zshi@redhat.com>