### PR TITLE
Add port to explosure port for containers.

### DIFF
--- a/docker-compose-dovetail.yml
+++ b/docker-compose-dovetail.yml
@@ -14,6 +14,8 @@ services:
       - /run
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     entrypoint: /sbin/init
+    ports:
+      - "8080:8080"
 
   logstash:
     build: 
@@ -26,6 +28,8 @@ services:
       - /run
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     entrypoint: /sbin/init
+    ports:
+      - "5044:5044"
 
   elasticsearch:
     build: 
@@ -38,6 +42,8 @@ services:
       - /run
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     entrypoint: /sbin/init
+    ports:
+      - "9200:9200"
 
   kibana:
     build: 
@@ -61,3 +67,6 @@ services:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     entrypoint: /sbin/init
+    ports:
+      - "443:443"
+      - "5601:5601"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - /run
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     entrypoint: /sbin/init
+    ports:
+      - "8080:8080"
 
   logstash:
     build: 
@@ -25,6 +27,8 @@ services:
       - /run
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     entrypoint: /sbin/init
+    ports:
+      - "5044:5044"
 
   elasticsearch:
     build: 
@@ -37,6 +41,8 @@ services:
       - /run
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     entrypoint: /sbin/init
+    ports:
+      - "9200:9200"
 
   kibana:
     build: 
@@ -49,3 +55,6 @@ services:
       - /run
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     entrypoint: /sbin/init
+    ports:
+      - "443:443"
+      - "5601:5601"

--- a/site.yml
+++ b/site.yml
@@ -29,10 +29,14 @@
 
   post_tasks:
     - name: Where is Kibana located?
-
       debug:
         msg: "Kibana can be reached at http://{{hostvars[inventory_hostname]['ansible_default_ipv4']['address']}}:5601/"
-      when: elk_deployed
+      when: elk_deployed and ansible_connection != 'docker'
+
+    - name: Where is Kibana located? (docker)
+      debug:
+        msg: "Kibana can be reached at http://localhost:5601/"
+      when: elk_deployed and ansible_connection == 'docker'
 
 - hosts: jenkins_master
   tags:
@@ -42,3 +46,9 @@
     - name: Where is Jenkins Master located?
       debug:
         msg: "Jenkins Master can be reached at http://{{hostvars[inventory_hostname]['ansible_default_ipv4']['address']}}:8080/"
+      when: ansible_connection != 'docker'
+
+    - name: Where is Jenkins Master located? (docker)
+      debug:
+        msg: "Jenkins Master can be reached at http://localhost:8080/"
+      when: ansible_connection == 'docker'


### PR DESCRIPTION
To explose docker's port to outside, adding 'port' statement in
docker-compose files. The messages (for kibana/jenkins URL) are
also modified to adjust docker cases.