### PR TITLE
Add JAVA_HOME for logstach container in case of docker

### DIFF
--- a/elk.yml
+++ b/elk.yml
@@ -29,6 +29,15 @@
     - { role: 'geerlingguy.java' }
     - { role: 'leifmadsen.logstash' }
 
+  post_tasks:
+    - name: Add JAVA_HOME in /etc/default/logstash
+      lineinfile:
+        dest=/etc/default/logstash
+        line='export JAVA_HOME=/usr/lib/jvm/jre'
+        create=yes
+      when: deploy_type is defined and deploy_type == 'docker'
+      notify: restart logstash
+
 - hosts: kibana
   become: true
   tags:


### PR DESCRIPTION
ansible-playbook does not run logstash in container due to missing
of JAVA_HOME. This fix is adding JAVA_HOME for running logstash.
https://github.com/redhat-nfvpe/toad/issues/80