### PR TITLE
Map container's volume to host machines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ files/
 !files/filebeat.yml
 .vagrant/
 vagrant/
+container_data/

--- a/docker-compose-dovetail.yml
+++ b/docker-compose-dovetail.yml
@@ -13,6 +13,10 @@ services:
     volumes:
       - /run
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - ./:/opt/toad
+      - ./container_data/jenkins/data:/var/lib/jenkins/userContent
+      - ./container_data/jenkins/log:/var/log/jenkins
+      - ./container_data/jenkins/jobs:/etc/jenkins_jobs
     entrypoint: /sbin/init
     ports:
       - "8080:8080"
@@ -27,6 +31,9 @@ services:
     volumes:
       - /run
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - ./:/opt/toad
+      - ./container_data/logstash/config:/etc/logstash/conf.d
+      - ./container_data/logstash/log:/var/log/logstash/logstash.log
     entrypoint: /sbin/init
     ports:
       - "5044:5044"
@@ -41,6 +48,10 @@ services:
     volumes:
       - /run
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - ./:/opt/toad
+      - ./container_data/elasticsearch/log:/var/log/elasticsearch
+      - ./container_data/elasticsearch/data:/var/lib/elasticsearch
+      - ./container_data/elasticsearch/config:/etc/elasticsearch
     entrypoint: /sbin/init
     ports:
       - "9200:9200"
@@ -55,6 +66,8 @@ services:
     volumes:
       - /run
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - ./:/opt/toad
+      - ./container_data/kibana/config:/opt/kibana/config
     entrypoint: /sbin/init
 
   dovetail:
@@ -66,6 +79,7 @@ services:
       - seccomp:unconfined
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - ./:/opt/toad
     entrypoint: /sbin/init
     ports:
       - "443:443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,10 @@ services:
     volumes:
       - /run
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - ./:/opt/toad
+      - ./container_data/jenkins/data:/var/lib/jenkins/userContent
+      - ./container_data/jenkins/log:/var/log/jenkins
+      - ./container_data/jenkins/jobs:/etc/jenkins_jobs
     entrypoint: /sbin/init
     ports:
       - "8080:8080"
@@ -26,6 +30,9 @@ services:
     volumes:
       - /run
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - ./:/opt/toad
+      - ./container_data/logstash/config:/etc/logstash/conf.d
+      - ./container_data/logstash/log:/var/log/logstash/logstash.log
     entrypoint: /sbin/init
     ports:
       - "5044:5044"
@@ -40,6 +47,10 @@ services:
     volumes:
       - /run
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - ./:/opt/toad
+      - ./container_data/elasticsearch/log:/var/log/elasticsearch
+      - ./container_data/elasticsearch/data:/var/lib/elasticsearch
+      - ./container_data/elasticsearch/config:/etc/elasticsearch
     entrypoint: /sbin/init
     ports:
       - "9200:9200"
@@ -54,6 +65,8 @@ services:
     volumes:
       - /run
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - ./:/opt/toad
+      - ./container_data/kibana/config:/opt/kibana/config
     entrypoint: /sbin/init
     ports:
       - "443:443"

--- a/dockerfiles/centos7_base
+++ b/dockerfiles/centos7_base
@@ -4,7 +4,7 @@ LABEL Name="TOAD" \
       Version="{placeholder}"
 
 RUN yum update -y && yum install -y sudo iproute epel-release && \
-    yum install -y openssh openssh-server openssh-clients && \
+    yum install -y openssh openssh-server openssh-clients git && \
     yum install -y python-pip && \
     sed -ie 's/requiretty/!requiretty/g' /etc/sudoers && \
     yum -y clean all

--- a/jenkins_jobs.yml
+++ b/jenkins_jobs.yml
@@ -83,10 +83,11 @@
       when: deploy_type is not defined or deploy_type != 'docker'
 
     - name: Synchronize job config to remote server (docker)
-      copy:
-        src: "{{ jenkins_job_config_file_src }}"
-        dest: "{{ jenkins_job_config_file_dest }}"
+      command: rsync -r "/opt/toad/{{ jenkins_job_config_file_src }}" "{{ jenkins_job_config_file_dest }}"
       when: deploy_type is defined and deploy_type == 'docker'
+      tags:
+        # Skip ANSIBLE0006. Synchronize module is not available docker.
+        - skip_ansible_lint
 
     - name: Locally clone TOAD envs
       git:
@@ -118,10 +119,11 @@
       when: deploy_type is not defined or deploy_type != 'docker'
 
     - name: Synchronize baremetal envs to remote server (docker)
-      copy:
-        src: "{{ jenkins_job_baremetal_env_file_src }}/{{ jenkins_job_baremetal_env_path }}"
-        dest: "{{ jenkins_job_baremetal_file_dest }}"
+      command: rsync -r "/opt/toad/{{ jenkins_job_baremetal_env_file_src }}" "{{ jenkins_job_baremetal_file_dest }}"
       when: deploy_type is defined and deploy_type == 'docker'
+      tags:
+        # Skip ANSIBLE0006. Synchronize module is not available docker.
+        - skip_ansible_lint
 
   roles:
     - { role: 'leifmadsen.jenkins-job-builder' }
@@ -155,15 +157,16 @@
     - name: Synchronize JJB config to remote server (docker)
       become: true
       become_user: jenkins
-      copy:
-        dest: "{{ jenkins_job_builder_file_jobs_dest }}"
-        src: "{{ item }}"
+      command: rsync -r "{{ item }}" "{{ jenkins_job_builder_file_jobs_dest }}"
       when: jenkins_job_builder_file_jobs_src != "" and
             (deploy_type is defined and deploy_type == 'docker')
-      with_items: "{{ jenkins_job_builder_file_jobs_src }}"
+      with_items: "{{ jenkins_job_builder_file_jobs_src_docker }}"
       notify:
         - Check jenkins
         - Reload jenkins-jobs
+      tags:
+        # Skip ANSIBLE0006. Synchronize module is not available docker.
+        - skip_ansible_lint
 
     - name: Results of JJB reload
       debug:

--- a/jenkins_jobs.yml
+++ b/jenkins_jobs.yml
@@ -83,9 +83,7 @@
       when: deploy_type is not defined or deploy_type != 'docker'
 
     - name: Synchronize job config to remote server (docker)
-      copy:
-        src: "{{ jenkins_job_config_file_src }}"
-        dest: "{{ jenkins_job_config_file_dest }}"
+      command: rsync -r "/opt/toad/{{ jenkins_job_config_file_src }}" "{{ jenkins_job_config_file_dest }}"
       when: deploy_type is defined and deploy_type == 'docker'
 
     - name: Locally clone TOAD envs
@@ -118,9 +116,7 @@
       when: deploy_type is not defined or deploy_type != 'docker'
 
     - name: Synchronize baremetal envs to remote server (docker)
-      copy:
-        src: "{{ jenkins_job_baremetal_env_file_src }}/{{ jenkins_job_baremetal_env_path }}"
-        dest: "{{ jenkins_job_baremetal_file_dest }}"
+      command: rsync -r "/opt/toad/{{ jenkins_job_baremetal_env_file_src }}" "{{ jenkins_job_baremetal_file_dest }}"
       when: deploy_type is defined and deploy_type == 'docker'
 
   roles:
@@ -155,12 +151,10 @@
     - name: Synchronize JJB config to remote server (docker)
       become: true
       become_user: jenkins
-      copy:
-        dest: "{{ jenkins_job_builder_file_jobs_dest }}"
-        src: "{{ item }}"
+      command: rsync -r "{{ item }}" "{{ jenkins_job_builder_file_jobs_dest }}"
       when: jenkins_job_builder_file_jobs_src != "" and
             (deploy_type is defined and deploy_type == 'docker')
-      with_items: "{{ jenkins_job_builder_file_jobs_src }}"
+      with_items: "/opt/toad/{{ jenkins_job_builder_file_jobs_src }}"
       notify:
         - Check jenkins
         - Reload jenkins-jobs

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -33,6 +33,7 @@ jenkins_job_builder_config_jenkins_url: "http://localhost:8080"
 jenkins_job_builder_config_job_builder_recursive: True
 jenkins_job_builder_git_jobs_src: "https://github.com/redhat-nfvpe/jenkins-jobs.git"
 jenkins_job_builder_file_jobs_src: "./files/jenkins-jobs"
+jenkins_job_builder_file_jobs_src_docker: "/opt/toad/files/jenkins-jobs"
 jenkins_job_builder_handler_check_retries: 10
 jenkins_job_builder_job_files:
   - "{{ jenkins_job_builder_file_jobs_src  }}/globals/"


### PR DESCRIPTION
This fix maps container's volume for user data (e.g. jenkins jjb)
to host machines (under container_data). This fix also changes
file copy for jenkins to use local rsync for performance.