### PR TITLE
[bugfix] Fixes deploy script in CentOS

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -20,9 +20,7 @@ if [ "$current_user" != "toad" ]; then
 fi
 
 msg "Setup the 'toad' user password for all-in-one."
-sudo su -
-echo "toad" | passwd toad --stdin
-logout
+sudo /bin/bash -c 'echo "toad" | passwd toad --stdin'
 
 pushd $HOME/toad
 


### PR DESCRIPTION
Apparently having the "sudo su -" in CentOS 7.3 wouldn't work, in that you'd run the script, and it'd stop at the point where it had "sudo su -" and you'd be at a prompt, and the script would not continue until you hit exit, and then it'd fail to change the password.

So I replaced that portion with just a `sudo /bin/bash -c '...'`