### PR TITLE
Fedora 23 and later uses DNF

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -40,6 +40,10 @@ if [ "$ID" = "centos" ]; then
     $pm install python python-pip -y
 fi
 
+if [ "$ID" = "fedora"] && [ $VERSION_ID -gt 22 ]; then
+    $pm install python2-dnf -y
+fi
+
 # install pre-requisites
 $pm makecache
 $pm install git ntp ansible libselinux-python -y


### PR DESCRIPTION
Install python-dnf2 for Ansible usage in Fedora 23 or later
so that we can access 'dnf' commands via the package module.