### PR TITLE
[bugfix][deploy] limits to just the jenkins_master host

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -48,4 +48,4 @@ msg "Spinning up a Jenkins Master."
 docker-compose up -d jenkins_master
 
 msg "Deploying a Jenkins Master and Slave."
-ansible-playbook site.yml --limit jenkins_master,jenkins_slave -e use_openstack_deploy=false -e deploy_type='docker' -c docker
+ansible-playbook site.yml --limit jenkins_master -e use_openstack_deploy=false -e deploy_type='docker' -c docker

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -25,7 +25,7 @@ sudo /bin/bash -c 'echo "toad" | passwd toad --stdin'
 pushd $HOME/toad
 
 msg "Configuring ~/.ansible/vars/toad_vars.yml."
-mkdir ~/.ansible/vars/
+mkdir -p ~/.ansible/vars/
 cat > ~/.ansible/vars/toad_vars.yml <<EOF
 elk_deployed: false
 filebeat_deployed: false


### PR DESCRIPTION
Fixes #102 

Gist is that it tries to kick off the "jenkins_slave" jobs in the deploy.sh which was causing this script to exit non-0. 

Minor fix, as it didn't cause the previous job to fail, that succeeds, but, just looks nicer in the output when it comes down to it.