### PR TITLE
[deploy] uses SSH keys for toad user

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -9,7 +9,7 @@ msg() {
 
 ############### Basic deployment
 
-msg "[!!!] This script will change the 'toad' user password and wipe it's ssh keys. Ctrl-C now to quit."
+msg "[!!!] This script will change the 'toad' user password and wipe its ssh keys. Ctrl-C now to quit."
 sleep 6
 
 current_user=$(whoami)


### PR DESCRIPTION
Fixes #102 

Uses SSH keys for toad user to log in via SSH to the slave, adds ssh key, adds public key to authorized_keys, and then sets proper creds in inventory file.