### PR TITLE
Path based traefik control doesn't work

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.backend=jenkins_master"
-      - "traefik.frontend.rule=Host:${PROXY_DOMAIN};Path:/jenkins"
+      - "traefik.frontend.rule=Host:jenkins.${PROXY_DOMAIN}"
       - "traefik.port=8080"
     expose:
       - "8080"
@@ -96,7 +96,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.backend=kibana"
-      - "traefik.frontend.rule=Host:${PROXY_DOMAIN};Path:/kibana"
+      - "traefik.frontend.rule=Host:kibana.${PROXY_DOMAIN}"
       - "traefik.port=5601"
     expose:
       - "5601"


### PR DESCRIPTION
Unfortunately when using a Path based redirect with traefik
things end up not working as expected. Switch this to using
a name based proxy.