### PR TITLE
[bug] Add test-requirements.txt for RTD

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,4 @@
+# Python packages required for documentation building
+sphinx
+sphinx_rtd_theme
+recommonmark


### PR DESCRIPTION
Using Sphinx for documentation and then building on read-the-docs
requires a test-requirements.txt which contains the required Python
modules to result in a successful build.