### PR TITLE
Support change of subnet range in default docker networks

### DIFF
--- a/docker-compose-dovetail.yml
+++ b/docker-compose-dovetail.yml
@@ -93,3 +93,9 @@ services:
     ports:
       - "443:443"
       - "5601:5601"
+
+networks:
+    default:
+      ipam:
+        config:
+            - subnet: 172.16.238.0/24

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,3 +100,9 @@ services:
       - "traefik.port=5601"
     expose:
       - "5601"
+
+networks:
+    default:
+      ipam:
+        config:
+          - subnet: 172.16.238.0/24


### PR DESCRIPTION
Give user ability to specify default subnet addresses
and avoid potential conflict with their own networks.

Signed-off-by: zshi <zshi@redhat.com>