### PR TITLE
[bug] Add matrix-project to list of plugins

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,6 +10,7 @@ jenkins_pkg_url: http://pkg.jenkins.io/redhat-stable
 jenkins_version: 2.32.2
 jenkins_repo_url: http://pkg.jenkins-ci.org/redhat-stable/jenkins.repo
 jenkins_plugins:
+  - matrix-project
   - build-timeout
   - copy-to-slave
   - credentials-binding


### PR DESCRIPTION
Several of the latest plugins seem to require the matrix-project plugin
so adding to the list of plugins that are installed by default.

Closes #132