### PR TITLE
Resolve issue with missing Xtrigger plugin

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -19,7 +19,9 @@ jenkins_plugins:
   - scp
   - ssh-slaves
   - ws-cleanup
-  - xtrigger
+  - fstrigger
+  - urltrigger
+  - buildresult-trigger
   - envinject
 jenkins_scp_sites:
   - hostname: 127.0.0.1


### PR DESCRIPTION
The Xtrigger plugin no longer seems to exist in the Jenkins
CI plugin list. XTrigger is just an aggregate plugin to
install several, so I'm replacing it with a subset of the
original list.

Closes issue #139